### PR TITLE
issue-61: cambios para que nivel pueda ser conectado a nestjs backend.

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -1,4 +1,6 @@
 NEXT_PUBLIC_API_URL=http://localhost:8000
+# Nestjs backend. Eventualmente, vamos a cambiar NEXT_PUBLIC_API_URL al nuevo backend
+NEXT_PUBLIC_BACKEND_URL=http://localhost:3000
 # buscar valores en bitwarden
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
 CLERK_SECRET_KEY=

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --port 3001",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/src/lib/api/nivel.ts
+++ b/src/lib/api/nivel.ts
@@ -1,9 +1,11 @@
 import axios from "axios";
 import { API_URL } from "../api";
 
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
+
 export const getNiveles = async () => {
     try {
-        const response = await axios.get(`${API_URL}/nivel/`);
+        const response = await axios.get(`${BACKEND_URL || API_URL}/nivel/`);
         return response.data;
       } catch (error: unknown) {
         console.error("Error al obtener niveles:", error);


### PR DESCRIPTION
Lo único que tendremos que cambiar es usar la puerta 3001 para el frontend.

primero tendremos que hacer merge en https://github.com/Skinner-SAS-de-CV/FastApi-Enpoints/pull/40 para no tener problemas en el entorno de desarollo.

Cuando tengamos el nestjs frontend, es solo definir `NEXT_PUBLIC_BACKEND_URL` para conectar el frontend. Después, limpiaremos las variables para solo usar un backend.