### PR TITLE
Borrando el result cuando usuario intenta analizar otro cv

### DIFF
--- a/src/app/analyze/components/AnalyzeForm.tsx
+++ b/src/app/analyze/components/AnalyzeForm.tsx
@@ -79,6 +79,7 @@ export default function AnalyzeForm({
     }
     setError(null);
     setLoading(true);
+    setResult(null);
 
     const formData = new FormData();
     formData.append("file", file);

--- a/src/app/candidate/analyze/components/AnalyzeForm.tsx
+++ b/src/app/candidate/analyze/components/AnalyzeForm.tsx
@@ -40,6 +40,7 @@ export default function AnalyzeForm({ saldo }: { saldo: number }) {
     }
     setError(null);
     setLoading(true);
+    setResult(null);
 
     const formData = new FormData();
     formData.append("file", file);


### PR DESCRIPTION

https://github.com/user-attachments/assets/a47512d3-1558-4d21-8214-b7a9f6aeb327

Básicamente el cambio es solo borrar el viejo result para que no interfiera con el nuevo result. Solo lo probé con el analisis de empresas, pero también hice el cambio en la página de candidatos(estoy seguro que también tiene este bug).